### PR TITLE
[REFACTOR] chatgpt api 연결 리펙토링, 카카오 클라이언트 패키지 이동

### DIFF
--- a/src/main/java/naeilmolae/domain/chatgpt/controller/ChatGptController.java
+++ b/src/main/java/naeilmolae/domain/chatgpt/controller/ChatGptController.java
@@ -22,11 +22,13 @@ public class ChatGptController {
 
     @PostMapping("/check-offensive")
     @Operation(summary = "부적절 문장 검증 API"
-            , description = "부적절한 문장인지 검증해서 Boolean 값으로 리턴하는 API입니다. 부적절한 문장이라면 true, 아니라면 false를 리턴합니다.")
+            , description = "상황에 부적절한 문장인지 검증해서 Boolean 값으로 리턴하는 API입니다. " +
+            "상황에 부적절한 문장이라면 true, 아니라면 false를 리턴합니다." +
+            "테스트용 api이기 \'우산을 챙기라는 말을 해주세요\'라는 상황으로 고정되어 있습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "검증 성공")
     })
     public Boolean checkOffensiveLanguage(@RequestBody String sentence) {
-        return chatGptService.checkForOffensiveLanguage(sentence);
+        return chatGptService.etCheckScriptRelevancePrompt(sentence, "우산 챙기라는 말을 해주세요");
     }
 }

--- a/src/main/java/naeilmolae/domain/chatgpt/service/ChatGptService.java
+++ b/src/main/java/naeilmolae/domain/chatgpt/service/ChatGptService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import naeilmolae.global.infrastructure.ai.OpenAiApiClient;
 import naeilmolae.global.infrastructure.ai.dto.request.ChatGptRequest;
 import naeilmolae.global.infrastructure.ai.dto.response.ChatGptResponse;
+import naeilmolae.global.templates.PromptManager;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -14,12 +15,11 @@ import java.util.List;
 public class ChatGptService {
 
     private final OpenAiApiClient openAiApiClient;
+    private final PromptManager promptManager;
 
     private final String model = "gpt-4o-mini";
 
     private final String systemRole = "system";
-    private final String systemPrompt = "You are an assistant that checks whether a sentence contains offensive " +
-            "language. Respond only with 'true' if the sentence contains offensive language and 'false' otherwise.";
 
     private final String userRole = "user";
     private final String userPrompt = "Is this sentence offensive: ";
@@ -28,12 +28,15 @@ public class ChatGptService {
     private final double temperature = 0.0;
 
 
-    public Boolean checkForOffensiveLanguage(String sentence) {
+    public Boolean etCheckScriptRelevancePrompt(String sentence, String Situation) {
+
+        // 템플릿 생성
+        String prompt = promptManager.createCheckForOffensiveLanguagePrompt(Situation);
 
         ChatGptResponse response = openAiApiClient.sendRequestToModel(
                 model,
                 List.of(
-                        new ChatGptRequest.ChatGptMessage(systemRole, systemPrompt),
+                        new ChatGptRequest.ChatGptMessage(systemRole, prompt),
                         new ChatGptRequest.ChatGptMessage(userRole, userPrompt + "'" + sentence + "'?")
                 ),
                 maxTokens,

--- a/src/main/java/naeilmolae/domain/member/client/KakaoMemberClient.java
+++ b/src/main/java/naeilmolae/domain/member/client/KakaoMemberClient.java
@@ -1,6 +1,6 @@
 package naeilmolae.domain.member.client;
 
-import naeilmolae.domain.member.dto.client.KakaoResponse;
+import naeilmolae.global.infrastructure.kakao.dto.KakaoResponse;
 import naeilmolae.global.common.exception.RestApiException;
 import naeilmolae.global.common.exception.code.status.AuthErrorStatus;
 import org.springframework.stereotype.Component;
@@ -18,6 +18,8 @@ public class KakaoMemberClient {
                 .build();
     }
 
+    // todo: 통신만 하는 책임으로 변경
+    // 그니까, 이 메서드는 클라이언트의 역할만 하도록 변경해야 해야 함
     public String getClientId(final String accessToken) {
         KakaoResponse response = webClient.get()
                 .header("Authorization", "Bearer " + accessToken)

--- a/src/main/java/naeilmolae/global/infrastructure/ai/OpenAiApiClient.java
+++ b/src/main/java/naeilmolae/global/infrastructure/ai/OpenAiApiClient.java
@@ -1,0 +1,28 @@
+package naeilmolae.global.infrastructure.ai;
+
+import lombok.RequiredArgsConstructor;
+import naeilmolae.global.infrastructure.ai.dto.request.ChatGptRequest;
+import naeilmolae.global.infrastructure.ai.dto.response.ChatGptResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAiApiClient {
+
+    private final WebClient webClient;
+
+    public ChatGptResponse sendRequestToModel(String model, List<ChatGptRequest.ChatGptMessage> messages, int maxTokens, double temperature) {
+        ChatGptRequest request = new ChatGptRequest(model, messages, maxTokens, temperature);
+
+        return webClient.post()
+                .uri("/chat/completions")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ChatGptResponse.class)
+                .block();
+    }
+}
+

--- a/src/main/java/naeilmolae/global/infrastructure/ai/dto/request/ChatGptRequest.java
+++ b/src/main/java/naeilmolae/global/infrastructure/ai/dto/request/ChatGptRequest.java
@@ -1,4 +1,4 @@
-package naeilmolae.domain.chatgpt.dto.request;
+package naeilmolae.global.infrastructure.ai.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/naeilmolae/global/infrastructure/ai/dto/response/ChatGptResponse.java
+++ b/src/main/java/naeilmolae/global/infrastructure/ai/dto/response/ChatGptResponse.java
@@ -1,4 +1,4 @@
-package naeilmolae.domain.chatgpt.dto.response;
+package naeilmolae.global.infrastructure.ai.dto.response;
 
 import lombok.Data;
 

--- a/src/main/java/naeilmolae/global/infrastructure/kakao/KakaoClient.java
+++ b/src/main/java/naeilmolae/global/infrastructure/kakao/KakaoClient.java
@@ -1,0 +1,4 @@
+package naeilmolae.global.infrastructure.kakao;
+
+public class KakaoClient {
+}

--- a/src/main/java/naeilmolae/global/infrastructure/kakao/dto/KakaoResponse.java
+++ b/src/main/java/naeilmolae/global/infrastructure/kakao/dto/KakaoResponse.java
@@ -1,4 +1,4 @@
-package naeilmolae.domain.member.dto.client;
+package naeilmolae.global.infrastructure.kakao.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/naeilmolae/global/templates/PromptManager.java
+++ b/src/main/java/naeilmolae/global/templates/PromptManager.java
@@ -15,7 +15,6 @@ public class PromptManager {
         return template.fillTemplate(request, responseFormat);
     }
 
-    //todo: 상황 별 validation이 안되는 듯
     public String createCheckForOffensiveLanguagePrompt( String situation ) {
         PromptTemplate template = new PromptTemplate();
         return template.fillTemplate(

--- a/src/main/java/naeilmolae/global/templates/PromptManager.java
+++ b/src/main/java/naeilmolae/global/templates/PromptManager.java
@@ -1,0 +1,39 @@
+package naeilmolae.global.templates;
+
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PromptManager {
+
+    private final String CheckForOffensiveLanguagePrompt = "You are an assistant that checks whether a sentence contains offensive " +
+            "language. Respond only with 'true' if the sentence contains offensive language and 'false' otherwise.";
+
+
+    public String createPrompt(String request, String responseFormat) {
+        PromptTemplate template = new PromptTemplate();
+        return template.fillTemplate(request, responseFormat);
+    }
+
+    //todo: 상황 별 validation이 안되는 듯
+    public String createCheckForOffensiveLanguagePrompt( String situation ) {
+        PromptTemplate template = new PromptTemplate();
+        return template.fillTemplate(
+                """
+                You are an assistant that evaluates whether a given script is appropriate for a specific situation. 
+                Consider the following factors:
+                - Relevance: Does the script directly address the given situation?
+                - Appropriateness: Does the script avoid offensive, negative, or harmful language?
+                - Clarity: Is the script clear and easy to understand?
+        
+                ### Situation
+                \'%s\' 라는 스크립트를 작성하는 상황
+                """.formatted(situation),
+                """
+                Respond with 'true' if the script is appropriate for the situation based on the above criteria. 
+                Respond with 'false' otherwise.
+                """
+        );
+    }
+
+}

--- a/src/main/java/naeilmolae/global/templates/PromptTemplate.java
+++ b/src/main/java/naeilmolae/global/templates/PromptTemplate.java
@@ -1,0 +1,25 @@
+package naeilmolae.global.templates;
+
+import org.springframework.stereotype.Component;
+
+public class PromptTemplate {
+
+    private static final String BASE_TEMPLATE = """
+            ### 요청하고 싶은 것
+            {{request}}
+                    
+            ### 응답 값 형식
+            {{responseFormat}}
+            """;
+
+    private final String template;
+
+    public PromptTemplate() {
+        this.template = BASE_TEMPLATE;
+    }
+
+    public String fillTemplate(String request, String responseFormat) {
+        return template.replace("{{request}}", request)
+                .replace("{{responseFormat}}", responseFormat);
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) refactor/#23/chat-gpt -> develop

## 변경 사항
- 프롬프트 매니저, 템플릿 분리
- openai 클라이언트 분리
- 카카오 클라이언트 패키지 이동

## 이슈